### PR TITLE
restructure profiles into separate files instead of being in the global `config.json` file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # OGJ Libium
-Libium is my own customized backend of [ogj-ferium](https://github.com/OgGhostJelly/ferium). It helps manage Minecraft mods from Modrinth, CurseForge, and Github Releases.
+OGJ Libium is my own customized backend of [ogj-ferium](https://github.com/OgGhostJelly/ferium). It helps manage Minecraft mods from Modrinth, CurseForge, and Github Releases.
 
 These are the main components of libium;
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# Libium
-Libium is the backend of [ferium](https://github.com/gorilla-devs/ferium). It helps manage Minecraft mods from Modrinth, CurseForge, and Github Releases.
+# OGJ Libium
+Libium is my own customized backend of [ogj-ferium](https://github.com/OgGhostJelly/ferium). It helps manage Minecraft mods from Modrinth, CurseForge, and Github Releases.
 
 These are the main components of libium;
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -54,7 +54,7 @@ pub fn write_config(path: impl AsRef<Path>, config: &structs::Config) -> Result<
 
 /// Serialise `profile` and write it to the profile file at `path`
 pub fn write_profile(path: impl AsRef<Path>, profile: &structs::Profile) -> Result<()> {
-    let profile_file = File::create(path)?;
+    let profile_file = File::create(&path)?;
     serde_json::to_writer_pretty(profile_file, profile)?;
     Ok(())
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -23,19 +23,38 @@ pub fn read_config(path: impl AsRef<Path>) -> Result<structs::Config> {
     }
 
     let config_file = BufReader::new(File::open(&path)?);
-    let mut config: structs::Config = serde_json::from_reader(config_file)?;
-
-    config
-        .profiles
-        .iter_mut()
-        .for_each(structs::Profile::backwards_compat);
+    let config: structs::Config = serde_json::from_reader(config_file)?;
 
     Ok(config)
+}
+
+pub fn read_profile(path: impl AsRef<Path>) -> Result<Option<structs::Profile>> {
+    let file = match File::open(&path) {
+        Ok(file) => file,
+        Err(e) if matches!(e.kind(), std::io::ErrorKind::NotFound) => return Ok(None),
+        Err(e) => return Err(e.into()),
+    };
+
+    let profile_file = BufReader::new(file);
+    let mut profile: structs::Profile = serde_json::from_reader(profile_file)?;
+    
+    profile.backwards_compat();
+
+    profile.mods.sort_unstable_by_key(|mod_| mod_.name.to_lowercase());
+
+    Ok(Some(profile))
 }
 
 /// Serialise `config` and write it to the config file at `path`
 pub fn write_config(path: impl AsRef<Path>, config: &structs::Config) -> Result<()> {
     let config_file = File::create(path)?;
     serde_json::to_writer_pretty(config_file, config)?;
+    Ok(())
+}
+
+/// Serialise `profile` and write it to the profile file at `path`
+pub fn write_profile(path: impl AsRef<Path>, profile: &structs::Profile) -> Result<()> {
+    let profile_file = File::create(path)?;
+    serde_json::to_writer_pretty(profile_file, profile)?;
     Ok(())
 }

--- a/src/config/structs.rs
+++ b/src/config/structs.rs
@@ -11,7 +11,7 @@ pub struct Config {
 
     #[serde(skip_serializing_if = "Vec::is_empty")]
     #[serde(default)]
-    pub profiles: Vec<Profile>,
+    pub profiles: Vec<PathBuf>,
 
     #[serde(skip_serializing_if = "is_zero")]
     #[serde(default)]

--- a/src/config/structs.rs
+++ b/src/config/structs.rs
@@ -24,17 +24,22 @@ pub struct Config {
 
 #[derive(Deserialize, Serialize, Debug, Default, Clone)]
 pub struct ProfileItem {
+    /// The path to the profile `.json` file.
     pub path: PathBuf,
+    /// The unique name of the profile.
     pub name: String,
+    /// The directory to download mod files to
+    pub output_dir: PathBuf,
 }
 
 impl ProfileItem {
-    pub fn from_name(name: String) -> std::io::Result<Self> {
+    pub fn infer_path(name: String, output_dir: PathBuf) -> std::io::Result<Self> {
         let mut path = current_dir()?.join(&name);
         path.set_extension("json");
         Ok(Self {
             path,
             name,
+            output_dir,
         })
     }
 }
@@ -59,9 +64,6 @@ pub enum ModpackIdentifier {
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct Profile {
-    /// The directory to download mod files to
-    pub output_dir: PathBuf,
-
     // There will be no filters when reading a v4 config
     #[serde(default)]
     pub filters: Vec<Filter>,
@@ -78,12 +80,10 @@ pub struct Profile {
 impl Profile {
     /// A simple contructor that automatically deals with converting to filters
     pub fn new(
-        output_dir: PathBuf,
         game_versions: Vec<String>,
         mod_loader: ModLoader,
     ) -> Self {
         Self {
-            output_dir,
             filters: vec![
                 Filter::ModLoaderPrefer(match mod_loader {
                     ModLoader::Quilt => vec![ModLoader::Quilt, ModLoader::Fabric],


### PR DESCRIPTION
Modified Libium to be able to handle profiles being stored as individual files instead of in the global `config.json` file. This change is not backwards compatible.